### PR TITLE
Enable handling 32bit codes.

### DIFF
--- a/IRRemote/arduino/irremote/irremote.ino
+++ b/IRRemote/arduino/irremote/irremote.ino
@@ -216,7 +216,7 @@ bool irSendHandler(HomieRange range, String value)
   String bits = getValue(value, ',', 1);
   String val = getValue(value, ',', 2);
   val.toCharArray(val_c, 128);
-  long rval = strtol(val_c, NULL, 16);
+  unsigned long rval = strtoul(val_c, NULL, 16);
 
   if(enc == "NEC") {
     // for now i only handle nec cause im lazy


### PR DESCRIPTION
strtol() doesn't handle values larger than 0x7FFFFFFF. Use strtoul() instead. A lot of devices require NEC codes with the Most Significant Bit set. ie. >=0x80000000.